### PR TITLE
fix: make llm enrichment resilient on ark/openai-compatible providers

### DIFF
--- a/src/enrichment/llm_client.js
+++ b/src/enrichment/llm_client.js
@@ -23,6 +23,14 @@ function safeJsonParse(raw) {
   }
 }
 
+function stripCodeFence(text) {
+  const value = String(text || '').trim();
+  if (!value) return '';
+  const match = value.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  if (match && match[1]) return String(match[1]).trim();
+  return value;
+}
+
 function isRetryableStatus(code) {
   if (!Number.isFinite(code)) return true;
   return code === 408 || code === 409 || code === 429 || code >= 500;
@@ -172,12 +180,63 @@ class OpenAICompatibleLlmClient {
       if (typeof message.content === 'string') return message.content.trim();
       if (Array.isArray(message.content)) {
         const chunks = message.content
-          .map((part) => (part && typeof part.text === 'string') ? part.text : '')
+          .map((part) => {
+            if (!part || typeof part !== 'object') return '';
+            if (typeof part.text === 'string') return part.text;
+            if (typeof part.content === 'string') return part.content;
+            return '';
+          })
           .filter(Boolean);
         if (chunks.length) return chunks.join('\n').trim();
       }
     }
+    if (typeof result.raw === 'string' && result.raw.trim()) {
+      return result.raw.trim();
+    }
     return '';
+  }
+
+  static normalizeTextCandidate(text) {
+    return stripCodeFence(String(text || '').trim());
+  }
+
+  static parseJsonCandidate(text) {
+    const normalized = OpenAICompatibleLlmClient.normalizeTextCandidate(text);
+    return safeJsonParse(normalized);
+  }
+
+  static matchesSchema(text, jsonSchema) {
+    if (!jsonSchema || typeof jsonSchema !== 'object') {
+      return Boolean(String(text || '').trim());
+    }
+
+    const parsed = OpenAICompatibleLlmClient.parseJsonCandidate(text);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+
+    const required = Array.isArray(jsonSchema.required) ? jsonSchema.required : [];
+    for (const key of required) {
+      if (!Object.prototype.hasOwnProperty.call(parsed, key)) return false;
+    }
+
+    if (jsonSchema.additionalProperties === false
+      && jsonSchema.properties
+      && typeof jsonSchema.properties === 'object') {
+      for (const key of Object.keys(parsed)) {
+        if (!Object.prototype.hasOwnProperty.call(jsonSchema.properties, key)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  static schemaKeys(jsonSchema) {
+    if (!jsonSchema || typeof jsonSchema !== 'object') return [];
+    if (jsonSchema.properties && typeof jsonSchema.properties === 'object') {
+      return Object.keys(jsonSchema.properties);
+    }
+    return [];
   }
 
   createStructuredOutputSync({
@@ -203,32 +262,97 @@ class OpenAICompatibleLlmClient {
       },
     };
 
-    let out;
-    try {
-      out = this.requestJsonSync('/responses', responsePayload);
-    } catch (err) {
-      const msg = String(err.message || '');
-      const shouldFallback = /404|405|unrecognized|unsupported|not found|unknown/i.test(msg);
-      if (!shouldFallback) throw err;
+    const errors = [];
 
-      const chatPayload = {
+    const tryCall = ({ label, path, payload }) => {
+      let out;
+      try {
+        out = this.requestJsonSync(path, payload);
+      } catch (err) {
+        errors.push(`${label}: ${String(err.message || err)}`);
+        return null;
+      }
+
+      const rawText = OpenAICompatibleLlmClient.extractTextFromResponse(out);
+      if (!rawText) {
+        errors.push(`${label}: empty text payload`);
+        return null;
+      }
+
+      if (!OpenAICompatibleLlmClient.matchesSchema(rawText, jsonSchema)) {
+        errors.push(`${label}: schema mismatch`);
+        return null;
+      }
+
+      return OpenAICompatibleLlmClient.normalizeTextCandidate(rawText);
+    };
+
+    const fromResponses = tryCall({
+      label: 'responses',
+      path: '/responses',
+      payload: responsePayload,
+    });
+    if (fromResponses) return fromResponses;
+
+    const baseMessages = [
+      { role: 'system', content: String(systemPrompt || '') },
+      { role: 'user', content: String(userPrompt || '') },
+    ];
+
+    const chatJsonSchema = tryCall({
+      label: 'chat:json_schema',
+      path: '/chat/completions',
+      payload: {
+        model: this.model,
+        temperature: this.temperature,
+        max_tokens: this.maxOutputTokens,
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'hippocore_memory_enrichment',
+            strict: true,
+            schema: jsonSchema,
+          },
+        },
+        messages: baseMessages,
+      },
+    });
+    if (chatJsonSchema) return chatJsonSchema;
+
+    const chatJsonObject = tryCall({
+      label: 'chat:json_object',
+      path: '/chat/completions',
+      payload: {
         model: this.model,
         temperature: this.temperature,
         max_tokens: this.maxOutputTokens,
         response_format: { type: 'json_object' },
+        messages: baseMessages,
+      },
+    });
+    if (chatJsonObject) return chatJsonObject;
+
+    const keys = OpenAICompatibleLlmClient.schemaKeys(jsonSchema);
+    const schemaHint = keys.length
+      ? `Return only JSON object with keys: ${keys.join(', ')}. No markdown.`
+      : 'Return only JSON object. No markdown.';
+
+    const chatPlain = tryCall({
+      label: 'chat:plain',
+      path: '/chat/completions',
+      payload: {
+        model: this.model,
+        temperature: this.temperature,
+        max_tokens: this.maxOutputTokens,
         messages: [
-          { role: 'system', content: String(systemPrompt || '') },
+          { role: 'system', content: `${String(systemPrompt || '')} ${schemaHint}`.trim() },
           { role: 'user', content: String(userPrompt || '') },
         ],
-      };
-      out = this.requestJsonSync('/chat/completions', chatPayload);
-    }
+      },
+    });
+    if (chatPlain) return chatPlain;
 
-    const text = OpenAICompatibleLlmClient.extractTextFromResponse(out);
-    if (!text) {
-      throw new Error('LLM response did not include text payload');
-    }
-    return text;
+    throw new Error(errors.length ? errors.join(' | ') : 'LLM response did not include text payload');
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes `llm enrichment` instability with OpenAI-compatible providers (especially Ark).

### What changed

- Improve `createStructuredOutputSync` fallback chain in `src/enrichment/llm_client.js`:
  1. `/responses` + `json_schema`
  2. `/chat/completions` + `response_format=json_schema`
  3. `/chat/completions` + `response_format=json_object`
  4. `/chat/completions` plain JSON-only prompt hint
- Add robust response handling:
  - strip fenced JSON blocks before parse
  - validate candidate payload against required schema keys
  - better extraction from message content variants
  - aggregate detailed fallback errors for diagnosis

### Why

Previously, some providers/models returned empty/timeout/non-conforming payloads on `/responses` or lacked `json_object` support, causing `llmSuccess=0` and fallback-to-rule only.

This update keeps strict behavior when possible, but gracefully degrades across provider quirks.

## Validation

- `npm test` passed: **33/33**
- Real runs against Ark models show improved success:
  - `deepseek-v3.2`: stable success
  - `doubao-seed-2.0-code`: stable success
  - `glm-4.7` / `doubao-seed-code`: partial success with fallback on some calls
  - `kimi-k2.5`: still timeout-prone in this environment

## Recommendation for default model

For this repo's current Ark setup, set enrichment default model to **doubao-seed-2.0-code**.
